### PR TITLE
Fix args of BCP cli command

### DIFF
--- a/src/Extractor/BCP.php
+++ b/src/Extractor/BCP.php
@@ -65,18 +65,18 @@ class BCP
         $serverName .= ',' . $this->dbParams['port'];
 
         $cmd = sprintf(
-            'bcp "%s" queryout %s -S "%s" -U %s -P "%s" -d %s -k -b50000 -m1 -t, -r"\n" -c',
-            $query,
-            $filename,
-            $serverName,
-            $this->dbParams['user'],
-            $this->dbParams['#password'],
-            $this->dbParams['database']
+            'bcp %s queryout %s -S %s -U %s -P %s -d %s -k -b50000 -m1 -t, -r"\n" -c',
+            escapeshellarg($query),
+            escapeshellarg($filename),
+            escapeshellarg($serverName),
+            escapeshellarg($this->dbParams['user']),
+            escapeshellarg($this->dbParams['#password']),
+            escapeshellarg($this->dbParams['database'])
         );
 
         $this->logger->info(sprintf(
             'Executing this BCP command: %s',
-            preg_replace('/\-P.".*".\-d/', '-P "*****" -d', $cmd)
+            preg_replace('/\-P.*\-d/', '-P ***** -d', $cmd)
         ));
 
         return $cmd;

--- a/src/Extractor/BCP.php
+++ b/src/Extractor/BCP.php
@@ -65,7 +65,7 @@ class BCP
         $serverName .= ',' . $this->dbParams['port'];
 
         $cmd = sprintf(
-            'bcp %s queryout %s -S %s -U %s -P %s -d %s -k -b50000 -m1 -t, -r"\n" -c',
+            'bcp %s queryout %s -S %s -U %s -P %s -d %s -q -k -b50000 -m1 -t, -r"\n" -c',
             escapeshellarg($query),
             escapeshellarg($filename),
             escapeshellarg($serverName),

--- a/tests/phpunit/ApplicationTest.php
+++ b/tests/phpunit/ApplicationTest.php
@@ -136,7 +136,7 @@ class ApplicationTest extends AbstractMSSQLTest
         $this->assertEquals(0, $process->getExitCode());
         $this->assertEquals('', $process->getErrorOutput());
         // verify that the bcp command uses the proxy
-        $this->assertStringContainsString('-S "127.0.0.1,1234"', $process->getOutput());
+        $this->assertStringContainsString('-S \'127.0.0.1,1234\'', $process->getOutput());
 
         $outputCsvData1 = iterator_to_array(new CsvFile($outputCsvFile1));
         $outputCsvData2 = iterator_to_array(new CsvFile($outputCsvFile2));
@@ -315,8 +315,6 @@ class ApplicationTest extends AbstractMSSQLTest
             $process->getErrorOutput()
         );
     }
-
-
 
     public function testDisableFallbackConfigRow(): void
     {


### PR DESCRIPTION
Changes:
- `BCP` cli command arguments were unescaped, so a more complex query (or password) could break the export.
- It is fixed using `escapeshellarg`.
- To `BCP` cli command was added `-q` parameter. It enables `QUOTED_IDENTIFIERS`, so behavior is same as PDO, and user can use `FROM sales`/`FROM [sales]`/`FROM "sales"` in query - and BCP will not fail.