### PR TITLE
Replace DEFAULT@SECLEVEL=2 -> 1 in openssl.cnf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,10 @@ RUN pecl install pdo_sqlsrv sqlsrv \
 # Set path
 ENV PATH $PATH:/opt/mssql-tools/bin
 
+# Fix SSL configuration to be compatible with older servers
+# https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
+RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf
+
 ## Composer - deps always cached unless changed
 # First copy only composer files
 COPY composer.* /code/


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-325

According to several sources, the openssl (update and) configuration may be the cause of the problem:
- https://www.terebellum.com/index.php/2020/03/04/debian-10-msphpsql-php-7-3-to-ms-sql-error-0x2746/
- https://social.msdn.microsoft.com/Forums/en-US/1bd36231-597d-47ae-bd2a-ae0b8843ed72/error-code-0x2746-connecting-to-locallyrunning-sql-server-on-linux?forum=sqltools
- We are not currently using SSL in this extractor, but maybe only the presence of another version of libssl causes problems.
- We need to find out if the problem is not in this ... and it is useful for the future when SSL will be implemented.
- Same problem in mysql: https://github.com/keboola/db-extractor-mysql/blob/ed19080f0d878c87587f69d08ee6aa05baaf80de/src/Keboola/DbExtractor/Extractor/MySQL.php#L27