### PR TITLE
Modify SSL min protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,11 @@ RUN pecl install pdo_sqlsrv sqlsrv \
 ENV PATH $PATH:/opt/mssql-tools/bin
 
 # Fix SSL configuration to be compatible with older servers
-# https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
-RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf
+RUN \
+    # https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
+    sed -i 's/CipherString\s*=.*/CipherString = DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf \
+    # https://stackoverflow.com/questions/53058362/openssl-v1-1-1-ssl-choose-client-version-unsupported-protocol
+    && sed -i 's/MinProtocol\s*=.*/MinProtocol = TLSv1/g' /etc/ssl/openssl.cnf
 
 ## Composer - deps always cached unless changed
 # First copy only composer files


### PR DESCRIPTION
Solving:
- https://keboola.atlassian.net/browse/COM-349
- https://keboola.atlassian.net/browse/COM-325

Changes:
- Fixed compatibility with older server, TLSv1 is enabled, ... original error msg was `Error connecting to DB: SQLSTATE[08001]: [Microsoft][ODBC Driver 17 for SQL Server]SSL Provider: [error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol]`