### PR TITLE
Fix line breaks detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4",
         "ext-PDO": "*",
         "ext-json": "*",
-        "keboola/csv": "^2.1",
+        "keboola/csv": "^2.2",
         "keboola/db-extractor-common": "^13.3",
         "keboola/db-extractor-config": "^1.4.6",
         "keboola/db-extractor-table-format": "^3.1.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4",
         "ext-PDO": "*",
         "ext-json": "*",
-        "keboola/csv": "^2.2",
+        "keboola/csv": "^2.2.1",
         "keboola/db-extractor-common": "^13.3",
         "keboola/db-extractor-config": "^1.4.6",
         "keboola/db-extractor-table-format": "^3.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e8e9f682c73cadba8205c6bd54fa59a",
+    "content-hash": "4b72e380ca56249a2991c248ee9920cc",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -115,22 +115,23 @@
         },
         {
             "name": "keboola/csv",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/php-csv.git",
-                "reference": "86f03def371e5b1a8a11973b496c86d3a0d4d57d"
+                "reference": "a439656d341494a73cc7fb57d0c3f47ac4267863"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-csv/zipball/86f03def371e5b1a8a11973b496c86d3a0d4d57d",
-                "reference": "86f03def371e5b1a8a11973b496c86d3a0d4d57d",
+                "url": "https://api.github.com/repos/keboola/php-csv/zipball/a439656d341494a73cc7fb57d0c3f47ac4267863",
+                "reference": "a439656d341494a73cc7fb57d0c3f47ac4267863",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6"
             },
             "require-dev": {
+                "ext-json": "*",
                 "phpunit/phpunit": "^5.7",
                 "squizlabs/php_codesniffer": "^3.2"
             },
@@ -156,7 +157,7 @@
                 "csv",
                 "rfc4180"
             ],
-            "time": "2019-11-11T08:02:32+00:00"
+            "time": "2020-07-28T06:23:02+00:00"
         },
         {
             "name": "keboola/db-extractor-common",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b72e380ca56249a2991c248ee9920cc",
+    "content-hash": "4d71311404c4e5c2dc535f8b6d43a7fc",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -115,16 +115,16 @@
         },
         {
             "name": "keboola/csv",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/php-csv.git",
-                "reference": "a439656d341494a73cc7fb57d0c3f47ac4267863"
+                "reference": "eb5a835a855f1bf03ddaa330e7b22fc5fb6042d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-csv/zipball/a439656d341494a73cc7fb57d0c3f47ac4267863",
-                "reference": "a439656d341494a73cc7fb57d0c3f47ac4267863",
+                "url": "https://api.github.com/repos/keboola/php-csv/zipball/eb5a835a855f1bf03ddaa330e7b22fc5fb6042d7",
+                "reference": "eb5a835a855f1bf03ddaa330e7b22fc5fb6042d7",
                 "shasum": ""
             },
             "require": {
@@ -157,7 +157,7 @@
                 "csv",
                 "rfc4180"
             ],
-            "time": "2020-07-28T06:23:02+00:00"
+            "time": "2020-07-28T09:27:05+00:00"
         },
         {
             "name": "keboola/db-extractor-common",

--- a/src/Extractor/Adapters/BcpAdapter.php
+++ b/src/Extractor/Adapters/BcpAdapter.php
@@ -198,6 +198,24 @@ class BcpAdapter
             ));
         }
 
+        try {
+            $output = $this->processOutputCsv($filename, $process);
+        } catch (BcpAdapterException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new BcpAdapterException(
+                'The BCP command produced an invalid csv: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+
+        $this->logger->info(sprintf('BCP successfully exported %d rows.', $output['rows']));
+        return $output;
+    }
+
+    private function processOutputCsv(string $filename, Process $process): array
+    {
         $outputFile = new CsvReader($filename);
         $numRows = 0;
         $lastFetchedRow = null;
@@ -219,7 +237,7 @@ class BcpAdapter
             }
             $numRows++;
         }
-        $this->logger->info(sprintf('BCP successfully exported %d rows.', $numRows));
+
         $output = ['rows' => $numRows];
         if ($lastFetchedRow) {
             $output['lastFetchedRow'] = $lastFetchedRow;

--- a/src/Extractor/Adapters/BcpAdapter.php
+++ b/src/Extractor/Adapters/BcpAdapter.php
@@ -233,7 +233,7 @@ class BcpAdapter
         $serverName .= $this->databaseConfig->hasPort() ? ',' . $this->databaseConfig->getPort() : '';
 
         $cmd = sprintf(
-            'bcp %s queryout %s -S %s -U %s -P %s -d %s -q -k -b50000 -m1 -t, -r"\n" -c',
+            'bcp %s queryout %s -S %s -U %s -P %s -d %s -q -k -b 50000 -m 1 -t "," -r "\n" -c',
             escapeshellarg($query),
             escapeshellarg($filename),
             escapeshellarg($serverName),


### PR DESCRIPTION
**Error in log:** https://my.papertrailapp.com/groups/23635/events?focus=1222931146619367425&q=%22keboola.ex-db-mssql%22%20AND%20%22exception%22%20AND%20%22attachment%22&selected=1222931146619367425

**Slack:** https://keboola.slack.com/archives/C09U3R1J4/p1595506745059500

**Error in older version:**
![image](https://user-images.githubusercontent.com/19371734/88290688-70391900-ccf7-11ea-9c81-df6c96887bef.png)

**Changes:**
- Line breaks detection was fixed in `php-csv` https://github.com/keboola/php-csv/pull/41, so package is updated.
- Preventive is catched every exception in `processOutputCsv` and is converted to `BcpAdapterException`, so in problems PDO fallback will be working.
- Fixed missing spaces in BCP command.
