### PR TITLE
Fix empty col name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "keboola/csv": "^2.2.1",
         "keboola/db-extractor-common": "^13.3",
         "keboola/db-extractor-config": "^1.4.6",
-        "keboola/db-extractor-table-format": "^3.1.2",
+        "keboola/db-extractor-table-format": "^3.1.3",
         "keboola/php-component": "^8.1.2",
         "keboola/php-datatypes": "^4.8",
         "symfony/config": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d71311404c4e5c2dc535f8b6d43a7fc",
+    "content-hash": "615cabd776dfe64471b5ad3e14a68f0c",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -298,16 +298,16 @@
         },
         {
             "name": "keboola/db-extractor-table-format",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-table-format.git",
-                "reference": "9aab5b6764962724f6e130f5237775f719649c0a"
+                "reference": "8a182c5221db084aa945b2b409bb2b7e64dae338"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-extractor-table-format/zipball/9aab5b6764962724f6e130f5237775f719649c0a",
-                "reference": "9aab5b6764962724f6e130f5237775f719649c0a",
+                "url": "https://api.github.com/repos/keboola/db-extractor-table-format/zipball/8a182c5221db084aa945b2b409bb2b7e64dae338",
+                "reference": "8a182c5221db084aa945b2b409bb2b7e64dae338",
                 "shasum": ""
             },
             "require": {
@@ -340,7 +340,7 @@
                 }
             ],
             "description": "PHP class for formating table result",
-            "time": "2020-07-01T10:38:21+00:00"
+            "time": "2020-07-28T13:21:26+00:00"
         },
         {
             "name": "keboola/php-component",

--- a/src/Metadata/MssqlMetadataProvider.php
+++ b/src/Metadata/MssqlMetadataProvider.php
@@ -67,6 +67,12 @@ class MssqlMetadataProvider implements MetadataProvider
 
             $columns = $this->pdo->runQuery($columnsSql);
             foreach ($columns as $data) {
+                if (empty(trim($data['COLUMN_NAME']))) {
+                    // In MsSQL, for the column name is allowed to consist only of spaces.
+                    // These columns are ignored.
+                    continue;
+                }
+
                 $tableId = $data['TABLE_SCHEMA'] . '.' . $data['TABLE_NAME'];
                 $tableBuilder = $tableBuilders[$tableId];
                 $this->processColumn($data, $tableBuilder);


### PR DESCRIPTION
Changes:
- Ignore empty (eg. `(space)`) column names in metadata.
- In MsSQL it is valid column name, but not in our metadata library (we trim it to empty string).