### PR TITLE
Fix edge-case - if column name contains only spaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "keboola/csv": "^2.2.1",
         "keboola/db-extractor-common": "^13.3",
         "keboola/db-extractor-config": "^1.4.6",
-        "keboola/db-extractor-table-format": "^3.1.2",
+        "keboola/db-extractor-table-format": "^3.1.4",
         "keboola/php-component": "^8.1.2",
         "keboola/php-datatypes": "^4.8",
         "symfony/config": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d71311404c4e5c2dc535f8b6d43a7fc",
+    "content-hash": "cd4b95b6f24fa9e9dc12bceae552eac0",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -298,16 +298,16 @@
         },
         {
             "name": "keboola/db-extractor-table-format",
-            "version": "3.1.2",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-table-format.git",
-                "reference": "9aab5b6764962724f6e130f5237775f719649c0a"
+                "reference": "15525f8ceddf20ef9f19cba2678f47288cea02e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-extractor-table-format/zipball/9aab5b6764962724f6e130f5237775f719649c0a",
-                "reference": "9aab5b6764962724f6e130f5237775f719649c0a",
+                "url": "https://api.github.com/repos/keboola/db-extractor-table-format/zipball/15525f8ceddf20ef9f19cba2678f47288cea02e1",
+                "reference": "15525f8ceddf20ef9f19cba2678f47288cea02e1",
                 "shasum": ""
             },
             "require": {
@@ -340,7 +340,7 @@
                 }
             ],
             "description": "PHP class for formating table result",
-            "time": "2020-07-01T10:38:21+00:00"
+            "time": "2020-07-29T10:18:23+00:00"
         },
         {
             "name": "keboola/php-component",

--- a/src/Metadata/MssqlMetadataProvider.php
+++ b/src/Metadata/MssqlMetadataProvider.php
@@ -90,7 +90,7 @@ class MssqlMetadataProvider implements MetadataProvider
     {
         $columnBuilder = $tableBuilder
             ->addColumn()
-            ->setName($data['COLUMN_NAME'])
+            ->setName($data['COLUMN_NAME'], false)
             ->setOrdinalPosition((int) $data['ORDINAL_POSITION']);
 
         // Type and length


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-352

Slack: https://keboola.slack.com/archives/CQ1ASK06M/p1595939846007000?thread_ts=1595493896.000800&cid=CQ1ASK06M

Changes:
- Updated table-format package.
- Column names are now not trimed.
- MsSQL column name that contains spaces, eg. col name = `(space)` is now working.

From doc https://docs.microsoft.com/en-us/sql/odbc/microsoft/column-name-limitations?view=sql-server-ver15:
```
Column names can contain any valid characters (for example, spaces). 
If column names contain any characters except letters, numbers, and underscores, 
the name must be delimited by enclosing it in back quotes (`).
```