### PR TITLE
Fix duplicate columns in metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "keboola/csv": "^2.2.1",
         "keboola/db-extractor-common": "^13.3",
         "keboola/db-extractor-config": "^1.4.6",
-        "keboola/db-extractor-table-format": "^3.1.4",
+        "keboola/db-extractor-table-format": "^3.1.5",
         "keboola/php-component": "^8.1.2",
         "keboola/php-datatypes": "^4.8",
         "symfony/config": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd4b95b6f24fa9e9dc12bceae552eac0",
+    "content-hash": "4623cbc91d442564c0aed63c27d0389e",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -298,16 +298,16 @@
         },
         {
             "name": "keboola/db-extractor-table-format",
-            "version": "3.1.4",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-extractor-table-format.git",
-                "reference": "15525f8ceddf20ef9f19cba2678f47288cea02e1"
+                "reference": "186ca533c8e5bc93891d9c60df085586488cdcb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-extractor-table-format/zipball/15525f8ceddf20ef9f19cba2678f47288cea02e1",
-                "reference": "15525f8ceddf20ef9f19cba2678f47288cea02e1",
+                "url": "https://api.github.com/repos/keboola/db-extractor-table-format/zipball/186ca533c8e5bc93891d9c60df085586488cdcb3",
+                "reference": "186ca533c8e5bc93891d9c60df085586488cdcb3",
                 "shasum": ""
             },
             "require": {
@@ -340,7 +340,7 @@
                 }
             ],
             "description": "PHP class for formating table result",
-            "time": "2020-07-29T10:18:23+00:00"
+            "time": "2020-07-30T08:08:11+00:00"
         },
         {
             "name": "keboola/php-component",

--- a/tests/phpunit/AbstractMSSQLTest.php
+++ b/tests/phpunit/AbstractMSSQLTest.php
@@ -77,16 +77,17 @@ abstract class AbstractMSSQLTest extends ExtractorTest
 
     private function setupTables(): void
     {
-        $csv1 = new SplFileInfo($this->dataDir . '/mssql/sales.csv');
+        $salesCsv = new SplFileInfo($this->dataDir . '/mssql/sales.csv');
         $specialCsv = new SplFileInfo($this->dataDir . '/mssql/special.csv');
 
         $this->dropTable('Empty Test');
+        $this->dropTable('simple');
         $this->dropTable('sales2');
         $this->dropTable('sales');
         $this->dropTable('special');
 
-        $this->createTextTable($csv1, ['createdat'], 'sales');
-        $this->createTextTable($csv1, null, 'sales2');
+        $this->createTextTable($salesCsv, ['createdat'], 'sales');
+        $this->createTextTable($salesCsv, null, 'sales2');
         $this->createTextTable($specialCsv, null, 'special');
         // drop the t1 demo table if it exists
         $this->dropTable('t1');
@@ -112,6 +113,9 @@ abstract class AbstractMSSQLTest extends ExtractorTest
             \"timestamp\" TIMESTAMP
             )"
         );
+
+        // create table simple
+        $this->pdo->exec('CREATE TABLE [simple] ("id" INT, "name" varchar(100), PRIMARY KEY ("id"))');
 
         // phpcs:disable Generic.Files.LineLength
         $this->pdo->exec('ALTER TABLE [auto Increment Timestamp] ADD CONSTRAINT PK_AUTOINC PRIMARY KEY ("_Weir%d I-D")');


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-353

Changes:
- Column with multiple constraints is only once in metadata (fixed bug).
  - `MssqlSqlHelper::getColumnsSqlComplex` returns SQL with `LEFT JOIN`s and it wasn't correctly handle in code.