### PR TITLE
Lock driver version to 17.5.2.1-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update \
     && ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
-    msodbcsql17 \
-    mssql-tools \
+    msodbcsql17=17.5.2.1-1 \
+    mssql-tools=17.5.2.1-1 \
     && rm -r /var/lib/apt/lists/* \
     && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen \


### PR DESCRIPTION
Changes:
- Driver version locked to `17.5.2.1-1`.
- Same version is locked in writer: https://github.com/keboola/db-writer-mssql/blob/472f55cc1a1617dc04911774c4f2f985bc2660de/Dockerfile#L15