### PR TITLE
Add long retry for problematic random error

### DIFF
--- a/src/Extractor/Adapters/PdoAdapter.php
+++ b/src/Extractor/Adapters/PdoAdapter.php
@@ -12,8 +12,8 @@ use Retry\RetryProxy;
 use Keboola\Csv\CsvWriter;
 use Keboola\DbExtractor\Extractor\PdoConnection;
 use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
-use Keboola\DbExtractor\DbRetryProxy;
 use Keboola\DbExtractor\Exception\UserException;
+use Keboola\DbExtractor\Extractor\MssqlRetryFactory;
 
 class PdoAdapter
 {
@@ -104,6 +104,6 @@ class PdoAdapter
 
     private function createRetryProxy(int $maxTries): RetryProxy
     {
-        return new DbRetryProxy($this->logger, $maxTries, [PDOException::class]);
+        return MssqlRetryFactory::createProxy($this->logger, $maxTries, null, [PDOException::class]);
     }
 }

--- a/src/Extractor/MssqlRetryFactory.php
+++ b/src/Extractor/MssqlRetryFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Extractor;
+
+use Psr\Log\LoggerInterface;
+use Retry\BackOff\ExponentialBackOffPolicy;
+use Retry\Policy\CallableRetryPolicy;
+use Retry\RetryProxy;
+use Throwable;
+
+class MssqlRetryFactory
+{
+    public static function createProxy(
+        LoggerInterface $logger,
+        int $maxTries,
+        ?int $timeout = null,
+        ?array $expectedExceptions = null
+    ): RetryProxy {
+        $timeout = $timeout ?? 15 * 60 * 1000; // default timeout, 15 min
+        $expectedExceptions = $expectedExceptions ?? ['PDOException', 'ErrorException'];
+
+        // Retry inverval 1s -> 2s -> 4s -> ... 60s
+        $backOffPolicy = new ExponentialBackOffPolicy(1000, 2, 60000);
+
+        // Retry policy
+        // We use by default "simple retry", see $maxTries
+        // For problematic error we use "timeout retry", see $timeout (more time is needed)
+        $exceptions = [];
+        $start = microtime(true);
+        $canRetry = function (Throwable $e) use (&$exceptions, $start, $maxTries, $expectedExceptions, $timeout) {
+            $ms = (microtime(true) - $start) * 1000;
+
+            // canRetry callback is called multiple times, so we count each unique exception
+            if (!in_array($e, $exceptions, true)) {
+                $exceptions[] = $e;
+            }
+
+            // Simple retry by default
+            if (count($exceptions) < $maxTries && self::shouldRetryForException($e, $expectedExceptions)) {
+                return true;
+            }
+
+            // Timeout retry for problematic error "error was encountered during handshakes before login ..."
+            $longRetryMsg = 'error was encountered during handshakes before login.';
+            if ($ms <= $timeout && strpos($e->getMessage(), $longRetryMsg) !== false) {
+                return true;
+            }
+
+            return false;
+        };
+        $retryPolicy = new CallableRetryPolicy($canRetry, 30);
+
+        return new RetryProxy($retryPolicy, $backOffPolicy, $logger);
+    }
+
+    private static function shouldRetryForException(Throwable $e, array $expectedExceptions): bool
+    {
+        foreach ($expectedExceptions as $class) {
+            if (is_a($e, $class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Extractor/PdoConnection.php
+++ b/src/Extractor/PdoConnection.php
@@ -79,7 +79,7 @@ class PdoConnection
 
     public function runRetryableQuery(string $query, int $maxTries, array $values = []): array
     {
-        $retryProxy = new DbRetryProxy($this->logger, $maxTries);
+        $retryProxy = MssqlRetryFactory::createProxy($this->logger, $maxTries);
         return $retryProxy->call(function () use ($query, $values): array {
             try {
                 return $this->runQuery($query, $values);
@@ -95,12 +95,7 @@ class PdoConnection
         try {
             $this->isAlive();
         } catch (DeadConnectionException $e) {
-            $reconnectionRetryProxy = new DbRetryProxy(
-                $this->logger,
-                DbRetryProxy::DEFAULT_MAX_TRIES,
-                null,
-                1000
-            );
+            $reconnectionRetryProxy = MssqlRetryFactory::createProxy($this->logger, DbRetryProxy::DEFAULT_MAX_TRIES);
             try {
                 $reconnectionRetryProxy->call(function (): void {
                     $this->connect();

--- a/tests/phpunit/MSSQLRetryTest.php
+++ b/tests/phpunit/MSSQLRetryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Keboola\DbExtractor\Extractor\MssqlRetryFactory;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\Test\TestLogger;
+use RuntimeException;
+
+class MSSQLRetryTest extends TestCase
+{
+    public function testNoRetry(): void
+    {
+        $logger = new TestLogger();
+        $proxy = MssqlRetryFactory::createProxy($logger, 3);
+
+        try {
+            $proxy->call(function (): void {
+                // Runtime exception is not in default expected exception's classse
+                throw new RuntimeException('Error!');
+            });
+            $this->fail('Expected RuntimeException.');
+        } catch (RuntimeException $e) {
+            // ok
+        }
+
+        $this->assertCount(0, $logger->records);
+    }
+
+    public function testSimpleRetry(): void
+    {
+        $logger = new TestLogger();
+        $timeout = 15 * 60 * 1000; // not used, 15 min
+        $maxTries = 4;
+        $proxy = MssqlRetryFactory::createProxy($logger, $maxTries, $timeout, [PDOException::class]);
+
+        $realTries = 0;
+        try {
+            $proxy->call(function () use (&$realTries): void {
+                $realTries++;
+                throw new PDOException('Error!');
+            });
+            $this->fail('Expected PdoException.');
+        } catch (PDOException $e) {
+            // ok
+        }
+
+        $this->assertSame($realTries, $maxTries);
+        $this->assertTrue($logger->hasInfoThatContains('Error!. Retrying... [1x]'));
+        $this->assertTrue($logger->hasInfoThatContains('Error!. Retrying... [2x]'));
+        $this->assertTrue($logger->hasInfoThatContains('Error!. Retrying... [3x]'));
+        $this->assertFalse($logger->hasInfoThatContains('Error!. Retrying... [4x]'));
+    }
+
+    public function testTimeoutRetryForProblematicError(): void
+    {
+        $logger = new TestLogger();
+        $timeout = 5 * 1000; // 5s
+        $maxTries = 1;
+        $proxy = MssqlRetryFactory::createProxy($logger, $maxTries, $timeout, [PDOException::class]);
+
+        $realTries = 0;
+        $start = microtime(true);
+        try {
+            $proxy->call(function () use (&$realTries): void {
+                $realTries++;
+                throw new PDOException(
+                    'Client unable to establish connection because ' .
+                    'an error was encountered during handshakes before login.'
+                );
+            });
+            $this->fail('Expected RuntimeException.');
+        } catch (PDOException $e) {
+            // ok
+        }
+        $end = microtime(true);
+        $durationMs = ($end - $start) * 1000;
+
+        // Proxy method is called 3x and retry takes 7 seconds (1s+2s+4s)
+        //     exception
+        //     [0s < 5s timeout] -> sleep 1s -> [1s < 5s timeout] -> retry
+        //     exception
+        //     [1s < 5s timeout] -> sleep 2s -> [3s < 5s timeout] -> retry
+        //     exception
+        //     [3s < 5s timeout] -> sleep 4s -> [7s > 5s timeout] -> NOT retry
+        $this->assertSame(3, $realTries);
+        $this->assertCount(3, $logger->records);
+        $this->assertGreaterThanOrEqual(7000, $durationMs);
+        $this->assertLessThan(8000, $durationMs);
+    }
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-419

The client receives a random error (~3x per week) `Client unable to establish connection because an error was encountered during handshakes before login. Common causes include client attempting to connect to an unsupported version of SQL Server, server too busy to accept new connections or a resource limitation (memory or maximum allowed connections) on the server.` 

Job after short retry fails.

There is probably a problem with the server ... but the client can't fix it, so we add longer retry for this error.

This error is now retried `15min` with `60s` interval.