### PR TITLE
skip BCP advanced query in sql server 2008 or less

### DIFF
--- a/src/Extractor/Adapters/BcpExportAdapter.php
+++ b/src/Extractor/Adapters/BcpExportAdapter.php
@@ -68,6 +68,12 @@ class BcpExportAdapter implements ExportAdapter
             throw new BcpAdapterSkippedException('Disabled in configuration.');
         }
 
+        if ($exportConfig->hasQuery() && $this->connection->getServerVersion() < 11) {
+            throw new BcpAdapterSkippedException(
+                'BCP is not supported for advanced queries in sql server 2008 or less.'
+            );
+        }
+
         $query = $exportConfig->hasQuery() ? $exportConfig->getQuery() : $this->createSimpleQuery($exportConfig);
 
         try {

--- a/tests/functional/clause-with-single-quote/expected-stdout
+++ b/tests/functional/clause-with-single-quote/expected-stdout
@@ -1,6 +1,7 @@
 Connecting to DSN 'sqlsrv:Server=mssql,1433;Database=test'
 Exporting "special" to "in.c-main.special".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT TOP 5 "usergender", "sku" FROM "sales" WHERE "usergender" LIKE '\''male'\''' queryout 'in.c-main.special.csv' -S 'mssql,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exported "5" rows to "in.c-main.special".
 Extractor finished successfully.

--- a/tests/functional/different-quoting/expected-stdout
+++ b/tests/functional/different-quoting/expected-stdout
@@ -1,6 +1,7 @@
 Connecting to DSN 'sqlsrv:Server=mssql,1433;Database=test'
 Exporting "special" to "in.c-main.special".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT usergender, [sku]  FROM sales WHERE "usergender" LIKE '\''male'\''' queryout 'in.c-main.special.csv' -S 'mssql,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exported "40" rows to "in.c-main.special".
 Extractor finished successfully.

--- a/tests/functional/error-invalid-query/expected-stdout
+++ b/tests/functional/error-invalid-query/expected-stdout
@@ -1,6 +1,7 @@
 Connecting to DSN 'sqlsrv:Server=mssql,1433;Database=test'
 Exporting "special" to "in.c-main.special".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT SOMETHING INVALID FROM "dbo"."special"' queryout 'in.c-main.special.csv' -S 'mssql,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exporting by "PDO" adapter.
 Connecting to DSN 'sqlsrv:Server=mssql,1433;Database=test'

--- a/tests/functional/pdo-fallback-disabled-config-row/expected-stdout
+++ b/tests/functional/pdo-fallback-disabled-config-row/expected-stdout
@@ -1,6 +1,7 @@
 Connecting to DSN 'sqlsrv:Server=mssql,1433;Database=test'
 Exporting "special" to "in.c-main.special".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT *  FROM "special";' queryout 'in.c-main.special.csv' -S 'mssql,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exporting by "PDO" adapter.
 Adapter "PDO" skipped: Disabled in configuration.

--- a/tests/functional/pdo-fallback-disabled/expected-stdout
+++ b/tests/functional/pdo-fallback-disabled/expected-stdout
@@ -1,6 +1,7 @@
 Connecting to DSN 'sqlsrv:Server=mssql,1433;Database=test'
 Exporting "special" to "in.c-main.special".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT *  FROM "special";' queryout 'in.c-main.special.csv' -S 'mssql,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exporting by "PDO" adapter.
 Adapter "PDO" skipped: Disabled in configuration.

--- a/tests/functional/pdo-fallback/expected-stdout
+++ b/tests/functional/pdo-fallback/expected-stdout
@@ -1,6 +1,7 @@
 Connecting to DSN 'sqlsrv:Server=mssql,1433;Database=test'
 Exporting "special" to "in.c-main.special".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT *  FROM "special";' queryout 'in.c-main.special.csv' -S 'mssql,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exporting by "PDO" adapter.
 Exported "7" rows to "in.c-main.special".

--- a/tests/functional/ssl-not-verify-cert-missing-certificate/expected-stdout
+++ b/tests/functional/ssl-not-verify-cert-missing-certificate/expected-stdout
@@ -2,6 +2,7 @@ Connecting to DSN 'sqlsrv:Server=mssql-ssl,1433;Database=test;Encrypt=true;Trust
 Using SSL connection
 Exporting "sales" to "in.c-main.sales".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT * FROM sales' queryout 'in.c-main.sales.csv' -S 'mssql-ssl,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exported "100" rows to "in.c-main.sales".
 Extractor finished successfully.

--- a/tests/functional/ssl-not-verify-cert-valid-certificate/expected-stdout
+++ b/tests/functional/ssl-not-verify-cert-valid-certificate/expected-stdout
@@ -2,6 +2,7 @@ Connecting to DSN 'sqlsrv:Server=mssql-ssl,1433;Database=test;Encrypt=true;Trust
 Using SSL connection
 Exporting "sales" to "in.c-main.sales".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT * FROM sales' queryout 'in.c-main.sales.csv' -S 'mssql-ssl,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exported "100" rows to "in.c-main.sales".
 Extractor finished successfully.

--- a/tests/functional/ssl-verify-cert-ignore-invalid-cn-certificate/expected-stdout
+++ b/tests/functional/ssl-verify-cert-ignore-invalid-cn-certificate/expected-stdout
@@ -3,6 +3,7 @@ Connecting to DSN 'sqlsrv:Server=mssql-ssl-invalid-cn,1433;Database=test;Encrypt
 Using SSL connection
 Exporting "sales" to "in.c-main.sales".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT * FROM sales' queryout 'in.c-main.sales.csv' -S 'mssql-ssl-invalid-cn,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exported "100" rows to "in.c-main.sales".
 Extractor finished successfully.

--- a/tests/functional/ssl-verify-cert-invalid-cn-certificate/expected-stdout
+++ b/tests/functional/ssl-verify-cert-invalid-cn-certificate/expected-stdout
@@ -3,6 +3,7 @@ Connecting to DSN 'sqlsrv:Server=mssql-ssl-invalid-cn,1433;Database=test;Encrypt
 Using SSL connection
 Exporting "sales" to "in.c-main.sales".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT * FROM sales' queryout 'in.c-main.sales.csv' -S 'mssql-ssl-invalid-cn,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exported "100" rows to "in.c-main.sales".
 Extractor finished successfully.

--- a/tests/functional/ssl-verify-cert-valid-certificate/expected-stdout
+++ b/tests/functional/ssl-verify-cert-valid-certificate/expected-stdout
@@ -2,6 +2,7 @@ Connecting to DSN 'sqlsrv:Server=mssql-ssl,1433;Database=test;Encrypt=true;Trust
 Using SSL connection
 Exporting "sales" to "in.c-main.sales".
 Exporting by "BCP" adapter.
+Found database server version: 14.0.3048.4
 Executing BCP command: bcp 'SELECT * FROM sales' queryout 'in.c-main.sales.csv' -S 'mssql-ssl,1433' -U 'sa' -P ***** -d 'test' -q -k -b 50000 -m 1 -t "," -r "\n" -c
 Exported "100" rows to "in.c-main.sales".
 Extractor finished successfully.


### PR DESCRIPTION
https://keboola.slack.com/archives/C09U3R1J4/p1618821309047200

zapomněl jsem tu na skip BCP exportu pro mssql server nížěí než 2008:
https://github.com/keboola/db-extractor-mssql/blob/6.5.3/src/Extractor/MSSQL.php#L117L119