### PR TITLE
Ignore bad utf-8 characters on BCP output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^7.4",
         "ext-PDO": "*",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "keboola/csv": "^2.2.1",
         "keboola/datadir-tests": "^5.2",
         "keboola/db-extractor-common": "^14.5",
@@ -24,8 +25,7 @@
         "symfony/process": "^5.0"
     },
     "require-dev": {
-        "ext-mbstring": "*",
-        "keboola/coding-standard": ">=9.0",
+      "keboola/coding-standard": ">=9.0",
         "phpstan/phpstan": "^0.12.14",
         "phpunit/phpunit": "^9.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e613e49b5a258734aced93a2304ff93d",
+    "content-hash": "2965d601d88ddc91a307d5d805e946a9",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -3973,10 +3973,9 @@
     "platform": {
         "php": "^7.4",
         "ext-pdo": "*",
-        "ext-json": "*"
-    },
-    "platform-dev": {
+        "ext-json": "*",
         "ext-mbstring": "*"
     },
+    "platform-dev": [],
     "plugin-api-version": "2.0.0"
 }

--- a/src/Extractor/Adapters/BcpExportAdapter.php
+++ b/src/Extractor/Adapters/BcpExportAdapter.php
@@ -229,7 +229,7 @@ class BcpExportAdapter implements ExportAdapter
                 throw new BcpAdapterException('The BCP command produced an invalid csv.', 0, null, [
                     'currentLineNumber' => $lineNumber,
                     'currentLine' => $outputFile->current(),
-                    'bcpErrorOutput' => $process->getErrorOutput(),
+                    'bcpErrorOutput' => mb_convert_encoding($process->getErrorOutput(), 'UTF-8', 'UTF-8'),
                 ]);
             }
             $lastRow = $outputFile->current();


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-833

Drobnost zo ZD, ktoru nema zmysel tlacit pred sebou.
Po fixnuti sa ukaze skutocna chyba, ... pravdepodobne, ze chyba podpora pre export binarnych typov.