### PR TITLE
fix: SUPPORT-10765 add explicit conversion for incremental datetime

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,11 +66,6 @@ parameters:
 			path: src/Extractor/MSSQLPdoConnection.php
 
 		-
-			message: "#^Offset 'lastFetchedRow' on array in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Extractor/MSSQLQueryFactory.php
-
-		-
 			message: "#^Invalid type mixed to throw\\.$#"
 			count: 1
 			path: tests/phpunit/ExceptionHandlingTest.php

--- a/tests/phpunit/QueryFactoryTest.php
+++ b/tests/phpunit/QueryFactoryTest.php
@@ -342,7 +342,7 @@ class QueryFactoryTest extends TestCase
                 'SELECT TOP 1000 [_Weir%d I-D], [Weir%d Na-me], [someInteger], [someDecimal], [type], ' .
                 '[smalldatetime], [datetime], CONVERT(NVARCHAR(MAX), ' .
                 'CONVERT(BINARY(8), [timestamp]), 1) AS [timestamp] ' .
-                "FROM [dbo].[auto Increment Timestamp] WHERE [datetime] >= '2018-10-26 10:52:32' ORDER BY [datetime]",
+                "FROM [dbo].[auto Increment Timestamp] WHERE [datetime] >= CONVERT(DATETIME2, '2018-10-26 10:52:32', 120) ORDER BY [datetime]",
             ],
             'test simplePDO query datetime column and previos state and limit and NOLOCK' => [
                 [
@@ -362,7 +362,7 @@ class QueryFactoryTest extends TestCase
                 '[smalldatetime], [datetime], CONVERT(NVARCHAR(MAX), ' .
                 'CONVERT(BINARY(8), [timestamp]), 1) AS [timestamp] ' .
                 'FROM [dbo].[auto Increment Timestamp] WITH(NOLOCK) ' .
-                "WHERE [datetime] >= '2018-10-26 10:52:32' ORDER BY [datetime]",
+                "WHERE [datetime] >= CONVERT(DATETIME2, '2018-10-26 10:52:32', 120) ORDER BY [datetime]",
             ],
         ];
         // @codingStandardsIgnoreEnd


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SUPPORT-10765

Bug ze supportu, v query jsme posílali datetime jako string '2025-02-13 10:11:10.210' což by mělo fungovat ale u tohoto specifického serveru (pravděpodobně nějaké nastavení locale/formát datetime) to dělalo problém. Přidal jsem explicitní convert na datetime2 s daným formátem.

Zkoušel jsem si jak samostatnou query tak pod dev tagem a fungovalo mi to. Snad to nerozbije nic jiného 🤞