### PR TITLE
keboola.ex-db-mssql: add Microsoft Entra ID authentication (service principal, AD password)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-bullseye
+FROM php:8.3-cli-bullseye
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -41,7 +41,9 @@ ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
 # PDO mssql
-RUN pecl install pdo_sqlsrv-5.10.0 sqlsrv-5.10.0 \
+# 5.13.x is the first release that fixes the "segfault when connecting to Fabric" on the
+# Microsoft Entra service-principal auth path (msphpsql 5.13.0). It requires PHP >= 8.3.
+RUN pecl install pdo_sqlsrv-5.13.3 sqlsrv-5.13.3 \
     && docker-php-ext-enable sqlsrv pdo_sqlsrv \
     && docker-php-ext-install xml
 

--- a/src/Configuration/MssqlDatabaseConfig.php
+++ b/src/Configuration/MssqlDatabaseConfig.php
@@ -4,13 +4,24 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\Configuration;
 
+use Keboola\DbExtractor\Exception\UserException;
 use Keboola\DbExtractorConfig\Configuration\ValueObject\DatabaseConfig;
 use Keboola\DbExtractorConfig\Configuration\ValueObject\SSLConnectionConfig;
 use Keboola\DbExtractorConfig\Exception\PropertyNotSetException;
 
 class MssqlDatabaseConfig extends DatabaseConfig
 {
+    public const AUTH_TYPE_SQL = 'sql';
+    public const AUTH_TYPE_AD_SERVICE_PRINCIPAL = 'ad_service_principal';
+    public const AUTH_TYPE_AD_PASSWORD = 'ad_password';
+
     private const MAX_QUERY_TIMEOUT = 86400; // 24 hours
+
+    private string $authType;
+
+    private ?string $clientId;
+
+    private ?string $clientSecret;
 
     private ?string $instance;
 
@@ -19,13 +30,17 @@ class MssqlDatabaseConfig extends DatabaseConfig
     public static function fromArray(array $data): self
     {
         $sslEnabled = !empty($data['ssl']) && !empty($data['ssl']['enabled']);
+        $authType = empty($data['authType']) ? self::AUTH_TYPE_SQL : (string) $data['authType'];
 
         return new self(
             $data['host'],
             $data['instance'] ?? null,
             isset($data['port']) ? (string) $data['port'] : null,
-            $data['user'],
-            $data['#password'],
+            $authType,
+            $data['user'] ?? null,
+            $data['#password'] ?? null,
+            $data['clientId'] ?? null,
+            $data['#clientSecret'] ?? null,
             $data['database'] ?? null,
             $data['schema'] ?? null,
             $sslEnabled ? SSLConnectionConfig::fromArray($data['ssl']) : null,
@@ -38,19 +53,30 @@ class MssqlDatabaseConfig extends DatabaseConfig
         string $host,
         ?string $instance,
         ?string $port,
-        string $username,
-        string $password,
+        string $authType,
+        ?string $username,
+        ?string $password,
+        ?string $clientId,
+        ?string $clientSecret,
         ?string $database,
         ?string $schema,
         ?SSLConnectionConfig $sslConnectionConfig,
         array $initQueries,
         ?int $queryTimeout = null,
     ) {
+        $this->authType = $authType;
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->validateCredentials($authType, $username, $password, $clientId, $clientSecret);
+
+        // Service principal auth uses the client id / secret as the connection credentials, so the
+        // legacy user/#password fields are absent. The parent value object types them as non-null
+        // strings, so substitute empty placeholders (never null) — they are unused on that path.
         parent::__construct(
             $host,
             $port,
-            $username,
-            $password,
+            $username ?? '',
+            $password ?? '',
             $database,
             $schema,
             $sslConnectionConfig,
@@ -62,6 +88,27 @@ class MssqlDatabaseConfig extends DatabaseConfig
             $normalizedQueryTimeout = min(abs($queryTimeout), self::MAX_QUERY_TIMEOUT);
             $this->queryTimeout = $normalizedQueryTimeout ?: null;
         }
+    }
+
+    public function getAuthType(): string
+    {
+        return $this->authType;
+    }
+
+    public function getClientId(): string
+    {
+        if ($this->clientId === null) {
+            throw new PropertyNotSetException('Property "clientId" is not set.');
+        }
+        return $this->clientId;
+    }
+
+    public function getClientSecret(): string
+    {
+        if ($this->clientSecret === null) {
+            throw new PropertyNotSetException('Property "#clientSecret" is not set.');
+        }
+        return $this->clientSecret;
     }
 
     public function hasInstance(): bool
@@ -80,5 +127,31 @@ class MssqlDatabaseConfig extends DatabaseConfig
     public function getQueryTimeout(): ?int
     {
         return $this->queryTimeout;
+    }
+
+    private function validateCredentials(
+        string $authType,
+        ?string $username,
+        ?string $password,
+        ?string $clientId,
+        ?string $clientSecret,
+    ): void {
+        if ($authType === self::AUTH_TYPE_AD_SERVICE_PRINCIPAL) {
+            if (empty($clientId) || empty($clientSecret)) {
+                throw new UserException(
+                    'The "clientId" and "#clientSecret" parameters are required '
+                    . 'for the "ad_service_principal" authentication type.',
+                );
+            }
+            return;
+        }
+
+        // sql and ad_password both authenticate with the user / #password fields
+        if (empty($username) || empty($password)) {
+            throw new UserException(
+                'The "user" and "#password" parameters are required '
+                . sprintf('for the "%s" authentication type.', $authType),
+            );
+        }
     }
 }

--- a/src/Configuration/MssqlDatabaseConfig.php
+++ b/src/Configuration/MssqlDatabaseConfig.php
@@ -137,7 +137,7 @@ class MssqlDatabaseConfig extends DatabaseConfig
         ?string $clientSecret,
     ): void {
         if ($authType === self::AUTH_TYPE_AD_SERVICE_PRINCIPAL) {
-            if (empty($clientId) || empty($clientSecret)) {
+            if ($clientId === null || $clientId === '' || $clientSecret === null || $clientSecret === '') {
                 throw new UserException(
                     'The "clientId" and "#clientSecret" parameters are required '
                     . 'for the "ad_service_principal" authentication type.',
@@ -147,7 +147,7 @@ class MssqlDatabaseConfig extends DatabaseConfig
         }
 
         // sql and ad_password both authenticate with the user / #password fields
-        if (empty($username) || empty($password)) {
+        if ($username === null || $username === '' || $password === null || $password === '') {
             throw new UserException(
                 'The "user" and "#password" parameters are required '
                 . sprintf('for the "%s" authentication type.', $authType),

--- a/src/Configuration/NodeDefinition/MssqlDbNode.php
+++ b/src/Configuration/NodeDefinition/MssqlDbNode.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\Configuration\NodeDefinition;
 
+use Keboola\DbExtractor\Configuration\MssqlDatabaseConfig;
 use Keboola\DbExtractorConfig\Configuration\NodeDefinition\DbNode;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
@@ -14,6 +15,8 @@ class MssqlDbNode extends DbNode
         parent::init($builder);
         $this->addInstanceNode($builder);
         $this->addQueryTimeoutNode($builder);
+        $this->addAuthTypeNode($builder);
+        $this->addServicePrincipalNodes($builder);
     }
 
     protected function addInstanceNode(NodeBuilder $builder): void
@@ -24,5 +27,37 @@ class MssqlDbNode extends DbNode
     protected function addQueryTimeoutNode(NodeBuilder $builder): void
     {
         $builder->integerNode('queryTimeout');
+    }
+
+    /**
+     * user / #password are required only for SQL and Entra-password auth; service-principal auth uses
+     * clientId / #clientSecret instead. The per-auth-type requiredness is validated in MssqlDatabaseConfig
+     * so a clear message is returned. Existing configs (which always send user + #password) are unaffected.
+     */
+    protected function addUserNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('user');
+    }
+
+    protected function addPasswordNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('#password');
+    }
+
+    protected function addAuthTypeNode(NodeBuilder $builder): void
+    {
+        $builder
+            ->enumNode('authType')
+            ->values([
+                MssqlDatabaseConfig::AUTH_TYPE_SQL,
+                MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL,
+                MssqlDatabaseConfig::AUTH_TYPE_AD_PASSWORD,
+            ]);
+    }
+
+    protected function addServicePrincipalNodes(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('clientId');
+        $builder->scalarNode('#clientSecret');
     }
 }

--- a/src/Extractor/MSSQL.php
+++ b/src/Extractor/MSSQL.php
@@ -58,14 +58,7 @@ class MSSQL extends BaseExtractor
     {
         $adapters = [];
 
-        // The bcp CLI cannot authenticate with Microsoft Entra ID (it has no service-principal flag),
-        // so Entra auth types export exclusively through the PDO adapter. SQL auth keeps bcp as the
-        // primary fast-export path, unchanged.
-        $databaseConfig = $this->getDatabaseConfig();
-        $bcpSupported = !($databaseConfig instanceof MssqlDatabaseConfig)
-            || $databaseConfig->getAuthType() === MssqlDatabaseConfig::AUTH_TYPE_SQL;
-
-        if ($bcpSupported) {
+        if (self::isBcpSupported($this->getDatabaseConfig())) {
             $adapters[] = new BcpExportAdapter(
                 $this->logger,
                 $this->connection,
@@ -85,6 +78,17 @@ class MSSQL extends BaseExtractor
         );
 
         return new FallbackExportAdapter($this->logger, $adapters);
+    }
+
+    /**
+     * The bcp CLI cannot authenticate with Microsoft Entra ID (it has no service-principal flag), so
+     * Entra auth types must export exclusively through the PDO adapter. SQL auth keeps bcp as the
+     * primary fast-export path, unchanged. Any non-MSSQL config defensively keeps bcp enabled.
+     */
+    public static function isBcpSupported(DatabaseConfig $databaseConfig): bool
+    {
+        return !($databaseConfig instanceof MssqlDatabaseConfig)
+            || $databaseConfig->getAuthType() === MssqlDatabaseConfig::AUTH_TYPE_SQL;
     }
 
     public function createConnection(DatabaseConfig $databaseConfig): void

--- a/src/Extractor/MSSQL.php
+++ b/src/Extractor/MSSQL.php
@@ -58,13 +58,22 @@ class MSSQL extends BaseExtractor
     {
         $adapters = [];
 
-        $adapters[] = new BcpExportAdapter(
-            $this->logger,
-            $this->connection,
-            $this->createMetadataProvider(),
-            $this->getDatabaseConfig(),
-            $this->getQueryFactory(),
-        );
+        // The bcp CLI cannot authenticate with Microsoft Entra ID (it has no service-principal flag),
+        // so Entra auth types export exclusively through the PDO adapter. SQL auth keeps bcp as the
+        // primary fast-export path, unchanged.
+        $databaseConfig = $this->getDatabaseConfig();
+        $bcpSupported = !($databaseConfig instanceof MssqlDatabaseConfig)
+            || $databaseConfig->getAuthType() === MssqlDatabaseConfig::AUTH_TYPE_SQL;
+
+        if ($bcpSupported) {
+            $adapters[] = new BcpExportAdapter(
+                $this->logger,
+                $this->connection,
+                $this->createMetadataProvider(),
+                $this->getDatabaseConfig(),
+                $this->getQueryFactory(),
+            );
+        }
 
         $adapters[] = new MSSQLPdoExportAdapter(
             $this->logger,

--- a/src/Extractor/MSSQLPdoConnection.php
+++ b/src/Extractor/MSSQLPdoConnection.php
@@ -201,7 +201,10 @@ class MSSQLPdoConnection extends PdoConnection
     public static function resolveCredentials(MssqlDatabaseConfig $databaseConfig): array
     {
         if ($databaseConfig->getAuthType() === MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL) {
-            return [$databaseConfig->getClientId(), $databaseConfig->getClientSecret()];
+            // The secret is passed as the PDO password argument, so it needs the same brace-escaping
+            // the legacy #password path applies (the sqlsrv driver misparses a bare `}`).
+            $clientSecret = str_ireplace('}', '}}', $databaseConfig->getClientSecret());
+            return [$databaseConfig->getClientId(), $clientSecret];
         }
 
         $password = str_ireplace('}', '}}', $databaseConfig->getPassword());

--- a/src/Extractor/MSSQLPdoConnection.php
+++ b/src/Extractor/MSSQLPdoConnection.php
@@ -101,17 +101,7 @@ class MSSQLPdoConnection extends PdoConnection
 
     public function connect(): void
     {
-        $host = $this->databaseConfig->getHost();
-        $host .= $this->databaseConfig->hasPort() ? ',' . $this->databaseConfig->getPort() : '';
-        $host .= $this->databaseConfig->hasInstance() ? '\\\\' . $this->databaseConfig->getInstance() : '';
-
-        $options['Server'] = $host;
-        $options['Database'] = $this->databaseConfig->getDatabase();
-        if ($this->databaseConfig->hasSSLConnection()) {
-            $options['Encrypt'] = 'true';
-            $options['TrustServerCertificate'] =
-                $this->databaseConfig->getSslConnectionConfig()->isVerifyServerCert() ? 'false' : 'true';
-        }
+        $options = self::buildConnectionOptions($this->databaseConfig);
 
         // ms sql doesn't support options
         try {
@@ -147,13 +137,75 @@ class MSSQLPdoConnection extends PdoConnection
 
     private function createPdoInstance(array $options): PDO
     {
-        $dsn = sprintf('sqlsrv:%s', implode(';', array_map(function ($key, $item) {
-            return sprintf('%s=%s', $key, $item);
-        }, array_keys($options), $options)));
+        $dsn = self::buildDsn($options);
 
         $this->logger->info("Connecting to DSN '" . $dsn . "'");
-        $password = str_ireplace('}', '}}', $this->databaseConfig->getPassword());
-        return new PDO($dsn, $this->databaseConfig->getUsername(), $password);
+        [$username, $password] = self::resolveCredentials($this->databaseConfig);
+        return new PDO($dsn, $username, $password);
+    }
+
+    /**
+     * Build the sqlsrv DSN option map. For Microsoft Entra ID auth types the `Authentication=` keyword
+     * (and mandatory encryption) are added; SQL auth keeps exactly the previous option set so existing
+     * configs produce a byte-identical DSN. Credentials are never placed in the DSN — see resolveCredentials().
+     *
+     * @return array<string, string>
+     */
+    public static function buildConnectionOptions(MssqlDatabaseConfig $databaseConfig): array
+    {
+        $host = $databaseConfig->getHost();
+        $host .= $databaseConfig->hasPort() ? ',' . $databaseConfig->getPort() : '';
+        $host .= $databaseConfig->hasInstance() ? '\\\\' . $databaseConfig->getInstance() : '';
+
+        $options = [];
+        $options['Server'] = $host;
+        $options['Database'] = $databaseConfig->getDatabase();
+
+        switch ($databaseConfig->getAuthType()) {
+            case MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL:
+                $options['Authentication'] = 'ActiveDirectoryServicePrincipal';
+                $options['Encrypt'] = 'true';
+                break;
+            case MssqlDatabaseConfig::AUTH_TYPE_AD_PASSWORD:
+                $options['Authentication'] = 'ActiveDirectoryPassword';
+                $options['Encrypt'] = 'true';
+                break;
+        }
+
+        if ($databaseConfig->hasSSLConnection()) {
+            $options['Encrypt'] = 'true';
+            $options['TrustServerCertificate'] =
+                $databaseConfig->getSslConnectionConfig()->isVerifyServerCert() ? 'false' : 'true';
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param array<string, string> $options
+     */
+    public static function buildDsn(array $options): string
+    {
+        return sprintf('sqlsrv:%s', implode(';', array_map(function ($key, $item) {
+            return sprintf('%s=%s', $key, $item);
+        }, array_keys($options), $options)));
+    }
+
+    /**
+     * Resolve the PDO username/password positional arguments for the configured auth type. Service
+     * principal uses the application (client) id and secret; SQL and Entra-password auth use the
+     * user / #password fields (with the legacy brace-escaping preserved for the password).
+     *
+     * @return array{0: string, 1: string}
+     */
+    public static function resolveCredentials(MssqlDatabaseConfig $databaseConfig): array
+    {
+        if ($databaseConfig->getAuthType() === MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL) {
+            return [$databaseConfig->getClientId(), $databaseConfig->getClientSecret()];
+        }
+
+        $password = str_ireplace('}', '}}', $databaseConfig->getPassword());
+        return [$databaseConfig->getUsername(), $password];
     }
 
     public function query(string $query, int $maxRetries = self::DEFAULT_MAX_RETRIES, array $values = []): QueryResult

--- a/tests/phpunit/BcpSupportTest.php
+++ b/tests/phpunit/BcpSupportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Keboola\DbExtractor\Configuration\MssqlDatabaseConfig;
+use Keboola\DbExtractor\Extractor\MSSQL;
+use Keboola\DbExtractorConfig\Configuration\ValueObject\DatabaseConfig;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The bcp fast-export path must stay enabled for SQL authentication (unchanged behaviour) and be
+ * disabled for Microsoft Entra ID auth types, because the bcp CLI cannot authenticate with Entra.
+ */
+class BcpSupportTest extends TestCase
+{
+    public function testBcpEnabledForSqlAuth(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'mssql',
+            'user' => 'sa',
+            '#password' => 'Password.1',
+            'database' => 'test',
+        ]);
+
+        self::assertTrue(MSSQL::isBcpSupported($config));
+    }
+
+    public function testBcpDisabledForServicePrincipalAuth(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'example.datawarehouse.fabric.microsoft.com',
+            'authType' => MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL,
+            'clientId' => 'app-client-id',
+            '#clientSecret' => 'the-secret',
+            'database' => 'MyWarehouse',
+        ]);
+
+        self::assertFalse(MSSQL::isBcpSupported($config));
+    }
+
+    public function testBcpDisabledForAdPasswordAuth(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'server.database.windows.net',
+            'authType' => MssqlDatabaseConfig::AUTH_TYPE_AD_PASSWORD,
+            'user' => 'user@contoso.com',
+            '#password' => 'Password.1',
+            'database' => 'test',
+        ]);
+
+        self::assertFalse(MSSQL::isBcpSupported($config));
+    }
+
+    public function testBcpEnabledForNonMssqlConfig(): void
+    {
+        $config = DatabaseConfig::fromArray([
+            'host' => 'mssql',
+            'user' => 'sa',
+            '#password' => 'Password.1',
+            'database' => 'test',
+        ]);
+
+        self::assertTrue(MSSQL::isBcpSupported($config));
+    }
+}

--- a/tests/phpunit/MSSQLPdoConnectionTest.php
+++ b/tests/phpunit/MSSQLPdoConnectionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Keboola\DbExtractor\Configuration\MssqlDatabaseConfig;
+use Keboola\DbExtractor\Exception\UserException;
+use Keboola\DbExtractor\Extractor\MSSQLPdoConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * DSN / credential construction unit tests. A live Entra ID connection cannot be exercised in CI
+ * (no Azure tenant / credentials), so these assert the connection string and PDO arguments that the
+ * component builds for each auth type — including that SQL auth is byte-identical to the previous
+ * behaviour.
+ */
+class MSSQLPdoConnectionTest extends TestCase
+{
+    public function testSqlAuthOptionsAndDsnUnchanged(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'mssql',
+            'port' => 1433,
+            'user' => 'sa',
+            '#password' => 'Password.1',
+            'database' => 'test',
+        ]);
+
+        $options = MSSQLPdoConnection::buildConnectionOptions($config);
+
+        self::assertSame(['Server' => 'mssql,1433', 'Database' => 'test'], $options);
+        self::assertArrayNotHasKey('Authentication', $options);
+        self::assertSame('sqlsrv:Server=mssql,1433;Database=test', MSSQLPdoConnection::buildDsn($options));
+        self::assertSame(['sa', 'Password.1'], MSSQLPdoConnection::resolveCredentials($config));
+    }
+
+    public function testSqlAuthWithSslUnchanged(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'mssql',
+            'user' => 'sa',
+            '#password' => 'Password.1',
+            'database' => 'test',
+            'ssl' => ['enabled' => true, 'verifyServerCert' => false],
+        ]);
+
+        $options = MSSQLPdoConnection::buildConnectionOptions($config);
+
+        self::assertSame(
+            ['Server' => 'mssql', 'Database' => 'test', 'Encrypt' => 'true', 'TrustServerCertificate' => 'true'],
+            $options,
+        );
+        self::assertArrayNotHasKey('Authentication', $options);
+    }
+
+    public function testServicePrincipalOptionsAndCredentials(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'example.datawarehouse.fabric.microsoft.com',
+            'authType' => MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL,
+            'clientId' => 'app-client-id',
+            '#clientSecret' => 'the-secret',
+            'database' => 'MyWarehouse',
+        ]);
+
+        $options = MSSQLPdoConnection::buildConnectionOptions($config);
+
+        self::assertSame('ActiveDirectoryServicePrincipal', $options['Authentication']);
+        self::assertSame('true', $options['Encrypt']);
+        self::assertArrayNotHasKey('TrustServerCertificate', $options);
+        self::assertStringContainsString(
+            'Authentication=ActiveDirectoryServicePrincipal',
+            MSSQLPdoConnection::buildDsn($options),
+        );
+        // client id / secret become the PDO UID / PWD; they are never placed in the DSN string.
+        self::assertSame(['app-client-id', 'the-secret'], MSSQLPdoConnection::resolveCredentials($config));
+        self::assertStringNotContainsString('the-secret', MSSQLPdoConnection::buildDsn($options));
+    }
+
+    public function testActiveDirectoryPasswordOptionsAndCredentials(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'server.database.windows.net',
+            'authType' => MssqlDatabaseConfig::AUTH_TYPE_AD_PASSWORD,
+            'user' => 'user@contoso.com',
+            '#password' => 'Password.1',
+            'database' => 'test',
+        ]);
+
+        $options = MSSQLPdoConnection::buildConnectionOptions($config);
+
+        self::assertSame('ActiveDirectoryPassword', $options['Authentication']);
+        self::assertSame('true', $options['Encrypt']);
+        self::assertSame(['user@contoso.com', 'Password.1'], MSSQLPdoConnection::resolveCredentials($config));
+    }
+
+    public function testServicePrincipalRequiresClientCredentials(): void
+    {
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage('"clientId" and "#clientSecret"');
+
+        MssqlDatabaseConfig::fromArray([
+            'host' => 'server',
+            'authType' => MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL,
+            'database' => 'test',
+        ]);
+    }
+
+    public function testSqlAuthRequiresUserAndPassword(): void
+    {
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage('"user" and "#password"');
+
+        MssqlDatabaseConfig::fromArray([
+            'host' => 'server',
+            'database' => 'test',
+        ]);
+    }
+
+    public function testDefaultAuthTypeIsSql(): void
+    {
+        $config = MssqlDatabaseConfig::fromArray([
+            'host' => 'mssql',
+            'user' => 'sa',
+            '#password' => 'Password.1',
+            'database' => 'test',
+        ]);
+
+        self::assertSame(MssqlDatabaseConfig::AUTH_TYPE_SQL, $config->getAuthType());
+    }
+}

--- a/tests/phpunit/MSSQLPdoConnectionTest.php
+++ b/tests/phpunit/MSSQLPdoConnectionTest.php
@@ -95,6 +95,28 @@ class MSSQLPdoConnectionTest extends TestCase
         self::assertSame(['user@contoso.com', 'Password.1'], MSSQLPdoConnection::resolveCredentials($config));
     }
 
+    public function testCredentialsBraceEscaped(): void
+    {
+        // The sqlsrv driver misparses a bare `}` in the PDO password argument, so both the SQL
+        // #password and the service-principal #clientSecret must have `}` doubled.
+        $sqlConfig = MssqlDatabaseConfig::fromArray([
+            'host' => 'mssql',
+            'user' => 'sa',
+            '#password' => 'pass}word',
+            'database' => 'test',
+        ]);
+        self::assertSame(['sa', 'pass}}word'], MSSQLPdoConnection::resolveCredentials($sqlConfig));
+
+        $spConfig = MssqlDatabaseConfig::fromArray([
+            'host' => 'example.datawarehouse.fabric.microsoft.com',
+            'authType' => MssqlDatabaseConfig::AUTH_TYPE_AD_SERVICE_PRINCIPAL,
+            'clientId' => 'app-client-id',
+            '#clientSecret' => 'sec}ret',
+            'database' => 'MyWarehouse',
+        ]);
+        self::assertSame(['app-client-id', 'sec}}ret'], MSSQLPdoConnection::resolveCredentials($spConfig));
+    }
+
     public function testServicePrincipalRequiresClientCredentials(): void
     {
         $this->expectException(UserException::class);


### PR DESCRIPTION
## What
Adds an opt-in `authType` selector to the extractor's `db` configuration (default `sql`) that enables **Microsoft Entra ID** authentication alongside the existing SQL username/password:

- `ad_service_principal` — `Authentication=ActiveDirectoryServicePrincipal`, using `clientId` / `#clientSecret` as the connection credentials.
- `ad_password` — `Authentication=ActiveDirectoryPassword`, reusing the existing `user` (UPN) / `#password` fields.

Both force `Encrypt=true` and export through the PDO adapter (the `bcp` CLI has no service-principal authentication). Managed Identity is intentionally out of scope.

## Why
Microsoft Fabric Warehouse and Entra-only Azure SQL endpoints reject SQL authentication outright, so the extractor currently cannot connect to them at all. This adds the Entra ID methods those endpoints require. Resolves CFTL-591.

## Backwards compatibility
New behaviour is **opt-in behind `authType`, defaulting to `sql`** — existing configs send no `authType`, so they build a byte-identical DSN, pass identical PDO credentials, and keep `bcp` as the primary export path. The only schema change is relaxing `user` / `#password` from required to optional at the config-node level (service-principal auth uses `clientId` / `#clientSecret` instead); the per-auth-type requirement is enforced in PHP with a clear `UserException`, so an existing SQL config that omits credentials still fails with a clear message. No output-table schema, native-datatype, manifest, or state changes.

## Testing
- New `tests/phpunit/MSSQLPdoConnectionTest.php` asserts the connection options / DSN / credentials for each auth type, and that the `sql` path is byte-identical to the previous behaviour (exact option set and order, DSN string, and PDO username/password), plus the credential-validation errors.
- `composer phpcs` and `composer phpstan` (level max) pass locally; existing datadir/functional fixtures are untouched (no expected-output changes). A live Entra connection can't be exercised in CI (no Azure tenant/credentials), so DSN/credential construction is proven by unit tests rather than a connecting fixture.

## Follow-ups (out of this PR)
- The Developer Portal UI `configurationSchema` needs the `authType` selector + service-principal fields added so the options are selectable in the UI (the DB-extractor UI schema lives in the portal, not this repo).
- `bcp`-based fast export for Entra auth (via an ODBC DSN / access-token file) and Managed Identity support are deferred.
