### PR TITLE
Defensive fix: keep user-classified DB errors from BCP query metadata out of internal errors (keboola.ex-db-mssql)

### DIFF
--- a/src/Extractor/Adapters/BcpQueryMetadata.php
+++ b/src/Extractor/Adapters/BcpQueryMetadata.php
@@ -71,6 +71,7 @@ class BcpQueryMetadata implements QueryMetadata
                 $e,
             );
         }
+
         // The connection layer already retries transient DB errors (PDOException) with
         // exponential backoff and, once the retries are exhausted, reports them as a user
         // exception - e.g. UserRetriedException for "Login timeout expired". Re-wrapping an

--- a/src/Extractor/Adapters/BcpQueryMetadata.php
+++ b/src/Extractor/Adapters/BcpQueryMetadata.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\Extractor\Adapters;
 
+use Keboola\CommonExceptions\UserExceptionInterface;
 use Keboola\DbExtractor\Adapter\Exception\UserException;
 use Keboola\DbExtractor\Adapter\ValueObject\QueryMetadata;
 use Keboola\DbExtractor\Exception\BcpAdapterException;
@@ -70,6 +71,20 @@ class BcpQueryMetadata implements QueryMetadata
                 $e,
             );
         }
+        // The connection layer already retries transient DB errors (PDOException) with
+        // exponential backoff and, once the retries are exhausted, reports them as a user
+        // exception - e.g. UserRetriedException for "Login timeout expired". Re-wrapping an
+        // exception that is already classified as user-facing into an ApplicationException
+        // downgrades it to an opaque "internal error" (exit code 2). Keep the original
+        // classification so the job exits 1 with the message the user can act on.
+        if ($e instanceof UserExceptionInterface) {
+            return new UserException(
+                sprintf('DB query "%s" failed: %s', $sql, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
         return new BcpAdapterException(
             sprintf('DB query "%s" failed: %s', $sql, $e->getMessage()),
             0,

--- a/tests/phpunit/BcpQueryMetadataErrorClassificationTest.php
+++ b/tests/phpunit/BcpQueryMetadataErrorClassificationTest.php
@@ -27,16 +27,21 @@ use Throwable;
  */
 class BcpQueryMetadataErrorClassificationTest extends TestCase
 {
+    private const QUERY = "EXEC sp_describe_first_result_set N'SELECT [id], [name] FROM [dbo].[items]', null, 0;";
+
     /**
-     * The connection layer retries transient DB errors (PDOException) with exponential
-     * backoff and, once the retries are exhausted, reports them as UserRetriedException.
-     * Such an already user-classified failure must stay a user error, otherwise the job
-     * ends with an opaque "internal error" (exit code 2) instead of an actionable
-     * message (exit code 1).
+     * A PDOException raised by the connection->query() call never reaches handleException()
+     * as-is: BaseDbConnection::callWithRetry() retries it with exponential backoff and, once
+     * the retries are exhausted, converts it to a UserRetriedException, which already
+     * implements UserExceptionInterface.
+     *
+     * Such an already user-classified failure must stay a user error, otherwise the job ends
+     * with an opaque "internal error" (exit code 2) instead of an actionable message (exit
+     * code 1).
      */
     public function testRetriedTransientDbErrorStaysUserException(): void
     {
-        $exception = $this->handleException(new UserRetriedException(
+        $exception = $this->classify(new UserRetriedException(
             5,
             'SQLSTATE[HYT00]: [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired',
         ));
@@ -47,12 +52,13 @@ class BcpQueryMetadataErrorClassificationTest extends TestCase
     }
 
     /**
-     * The same holds for the UserException that getColumns() itself raises when the
-     * metadata result is incomplete - its message is written for the user.
+     * The same holds for the UserException that getColumns() itself raises when the metadata
+     * result is incomplete - its message is written for the user, so it must not be reported
+     * as an internal error either.
      */
     public function testUserExceptionIsNotDowngraded(): void
     {
-        $exception = $this->handleException(new UserException('Cannot retrieve all column metadata'));
+        $exception = $this->classify(new UserException('Cannot retrieve all column metadata'));
 
         $this->assertInstanceOf(UserExceptionInterface::class, $exception);
         $this->assertNotInstanceOf(ApplicationExceptionInterface::class, $exception);
@@ -60,12 +66,12 @@ class BcpQueryMetadataErrorClassificationTest extends TestCase
     }
 
     /**
-     * Unchanged behaviour: anything that is not already user-classified is still wrapped
-     * in a BcpAdapterException (an ApplicationException).
+     * Unchanged behaviour: anything that is not already user-classified is still wrapped in a
+     * BcpAdapterException (an ApplicationException).
      */
     public function testUnexpectedErrorStillBecomesApplicationException(): void
     {
-        $exception = $this->handleException(new RuntimeException('Something unexpected'));
+        $exception = $this->classify(new RuntimeException('Something unexpected'));
 
         $this->assertInstanceOf(BcpAdapterException::class, $exception);
         $this->assertInstanceOf(ApplicationExceptionInterface::class, $exception);
@@ -74,12 +80,13 @@ class BcpQueryMetadataErrorClassificationTest extends TestCase
     }
 
     /**
-     * Unchanged behaviour: a raw PDOException (not retried by the connection layer) is
-     * still reported as a BcpAdapterException.
+     * Unchanged behaviour, and a reachable path rather than a dead guard: getColumns() calls
+     * fetchAll() on the result *outside* callWithRetry(), so a fetch-time PDOException arrives
+     * here un-wrapped and is still reported as a BcpAdapterException.
      */
-    public function testPdoExceptionStillBecomesApplicationException(): void
+    public function testRawPdoExceptionStillBecomesApplicationException(): void
     {
-        $exception = $this->handleException(new PDOException('SQLSTATE[42S02]: Base table not found'));
+        $exception = $this->classify(new PDOException('SQLSTATE[42S02]: Base table not found'));
 
         $this->assertInstanceOf(BcpAdapterException::class, $exception);
         $this->assertInstanceOf(ApplicationExceptionInterface::class, $exception);
@@ -87,14 +94,14 @@ class BcpQueryMetadataErrorClassificationTest extends TestCase
     }
 
     /**
-     * Unchanged behaviour: the "uses a temp table" branch keeps its own dedicated
-     * message and still takes precedence over the generic handling.
+     * Unchanged behaviour: the "uses a temp table" branch is evaluated first, so it keeps its
+     * own dedicated message and still takes precedence over the generic handling.
      */
     public function testTempTableErrorKeepsDedicatedMessage(): void
     {
-        $exception = $this->handleException(new PDOException(
+        $exception = $this->classify(new PDOException(
             '[Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The metadata could not be determined '
-            . "because statement 'delete from #ErrFile' uses a temp table.",
+            . "because statement 'delete from #tmp' uses a temp table.",
         ));
 
         $this->assertInstanceOf(UserException::class, $exception);
@@ -102,14 +109,13 @@ class BcpQueryMetadataErrorClassificationTest extends TestCase
         $this->assertStringContainsString('uses a temp table.', $exception->getMessage());
     }
 
-    private function handleException(Throwable $exception): Throwable
+    private function classify(Throwable $exception): Throwable
     {
-        $query = 'SELECT 1';
-        $object = new BcpQueryMetadata($this->createMock(MSSQLPdoConnection::class), $query);
+        $object = new BcpQueryMetadata($this->createMock(MSSQLPdoConnection::class), self::QUERY);
 
         $method = (new ReflectionClass($object))->getMethod('handleException');
         $method->setAccessible(true);
-        $result = $method->invoke($object, $exception, $query);
+        $result = $method->invoke($object, $exception, self::QUERY);
 
         $this->assertInstanceOf(Throwable::class, $result);
 

--- a/tests/phpunit/BcpQueryMetadataErrorClassificationTest.php
+++ b/tests/phpunit/BcpQueryMetadataErrorClassificationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Keboola\CommonExceptions\ApplicationExceptionInterface;
+use Keboola\CommonExceptions\UserExceptionInterface;
+use Keboola\DbExtractor\Adapter\Exception\UserException;
+use Keboola\DbExtractor\Adapter\Exception\UserRetriedException;
+use Keboola\DbExtractor\Exception\BcpAdapterException;
+use Keboola\DbExtractor\Extractor\Adapters\BcpQueryMetadata;
+use Keboola\DbExtractor\Extractor\MSSQLPdoConnection;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Covers how BcpQueryMetadata classifies a failure of the sp_describe_first_result_set
+ * metadata query. getColumns() is called lazily by the manifest generator, i.e. after
+ * BcpExportAdapter::export() has already returned, so nothing else re-classifies the
+ * exception afterwards - whatever handleException() returns is what the job dies with.
+ *
+ * These tests need no database: handleException() is pure and the connection is mocked.
+ */
+class BcpQueryMetadataErrorClassificationTest extends TestCase
+{
+    /**
+     * The connection layer retries transient DB errors (PDOException) with exponential
+     * backoff and, once the retries are exhausted, reports them as UserRetriedException.
+     * Such an already user-classified failure must stay a user error, otherwise the job
+     * ends with an opaque "internal error" (exit code 2) instead of an actionable
+     * message (exit code 1).
+     */
+    public function testRetriedTransientDbErrorStaysUserException(): void
+    {
+        $exception = $this->handleException(new UserRetriedException(
+            5,
+            'SQLSTATE[HYT00]: [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired',
+        ));
+
+        $this->assertInstanceOf(UserExceptionInterface::class, $exception);
+        $this->assertNotInstanceOf(ApplicationExceptionInterface::class, $exception);
+        $this->assertStringContainsString('Login timeout expired', $exception->getMessage());
+    }
+
+    /**
+     * The same holds for the UserException that getColumns() itself raises when the
+     * metadata result is incomplete - its message is written for the user.
+     */
+    public function testUserExceptionIsNotDowngraded(): void
+    {
+        $exception = $this->handleException(new UserException('Cannot retrieve all column metadata'));
+
+        $this->assertInstanceOf(UserExceptionInterface::class, $exception);
+        $this->assertNotInstanceOf(ApplicationExceptionInterface::class, $exception);
+        $this->assertStringContainsString('Cannot retrieve all column metadata', $exception->getMessage());
+    }
+
+    /**
+     * Unchanged behaviour: anything that is not already user-classified is still wrapped
+     * in a BcpAdapterException (an ApplicationException).
+     */
+    public function testUnexpectedErrorStillBecomesApplicationException(): void
+    {
+        $exception = $this->handleException(new RuntimeException('Something unexpected'));
+
+        $this->assertInstanceOf(BcpAdapterException::class, $exception);
+        $this->assertInstanceOf(ApplicationExceptionInterface::class, $exception);
+        $this->assertNotInstanceOf(UserExceptionInterface::class, $exception);
+        $this->assertStringContainsString('Something unexpected', $exception->getMessage());
+    }
+
+    /**
+     * Unchanged behaviour: a raw PDOException (not retried by the connection layer) is
+     * still reported as a BcpAdapterException.
+     */
+    public function testPdoExceptionStillBecomesApplicationException(): void
+    {
+        $exception = $this->handleException(new PDOException('SQLSTATE[42S02]: Base table not found'));
+
+        $this->assertInstanceOf(BcpAdapterException::class, $exception);
+        $this->assertInstanceOf(ApplicationExceptionInterface::class, $exception);
+        $this->assertStringContainsString('Base table not found', $exception->getMessage());
+    }
+
+    /**
+     * Unchanged behaviour: the "uses a temp table" branch keeps its own dedicated
+     * message and still takes precedence over the generic handling.
+     */
+    public function testTempTableErrorKeepsDedicatedMessage(): void
+    {
+        $exception = $this->handleException(new PDOException(
+            '[Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The metadata could not be determined '
+            . "because statement 'delete from #ErrFile' uses a temp table.",
+        ));
+
+        $this->assertInstanceOf(UserException::class, $exception);
+        $this->assertStringContainsString('Cannot retrieve column metadata via query', $exception->getMessage());
+        $this->assertStringContainsString('uses a temp table.', $exception->getMessage());
+    }
+
+    private function handleException(Throwable $exception): Throwable
+    {
+        $query = 'SELECT 1';
+        $object = new BcpQueryMetadata($this->createMock(MSSQLPdoConnection::class), $query);
+
+        $method = (new ReflectionClass($object))->getMethod('handleException');
+        $method->setAccessible(true);
+        $result = $method->invoke($object, $exception, $query);
+
+        $this->assertInstanceOf(Throwable::class, $result);
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Summary
A transient MSSQL connection failure during BCP query-metadata retrieval was reported as an
opaque **internal error (exit code 2)** instead of an actionable user error (exit code 1).
This keeps the classification the connection layer already made. No change to the
component's behaviour on inputs that already worked.

## Root cause
`Keboola\DbExtractor\Exception\BcpAdapterException` at `src/Extractor/Adapters/BcpQueryMetadata.php:73`
— `EXEC sp_describe_first_result_set` failed with `SQLSTATE[HYT00] ... Login timeout expired`.

The chain:

1. The metadata query hits a `PDOException` (login timeout).
2. `MSSQLPdoConnection::query()` retries it 5x with exponential backoff (`BaseDbConnection::callWithRetry`)
   and, once the retries are exhausted, converts it to a `UserRetriedException`
   — which **already implements `UserExceptionInterface`**.
3. `BcpQueryMetadata::handleException()` catches that and re-wraps it in `BcpAdapterException`,
   which extends `ApplicationException` (`ApplicationExceptionInterface`).
4. `src/run.php` therefore falls through to the `Throwable` branch → `logger->critical()` → **exit 2**.

Because `getColumns()` is invoked **lazily** by the manifest generator (after
`BcpExportAdapter::export()` has already returned), the `catch (BcpAdapterException) → UserException`
conversion at `BcpExportAdapter.php:92` never applies to it — so this path is the one place a
user-classified DB error still surfaced as an internal error.

Classified as **transient**; 1 occurrence in the alert window. Retrying more is not the fix — the
connection layer already retried 5x. The defect is purely in how the exhausted failure is reported.

## Fix
In `BcpQueryMetadata::handleException()`, if the caught throwable already implements
`UserExceptionInterface`, return a `UserException` with the **same message text** instead of
downgrading it to `BcpAdapterException`. Everything else is unchanged.

This also fixes the same downgrade for the `UserException` that `getColumns()` raises itself when
the metadata result is incomplete — its message is written for the user but was being reported as
an internal error too.

## Behaviour impact: none — defensive-only
- The success path of `getColumns()` is untouched. No outputs, transforms, manifest columns,
  schema, or config semantics changed.
- A failing run **still fails**. Only the exception class changes, so the exit code goes 2 → 1 and
  the user sees the cause instead of "internal error". Nothing is swallowed and nothing succeeds silently.
- The message string is byte-identical (`DB query "%s" failed: %s`).
- The `uses a temp table` branch still takes precedence and keeps its dedicated message.
- Any throwable that is *not* already user-classified (raw `PDOException`, `RuntimeException`, …)
  still becomes a `BcpAdapterException` exactly as before.
- Retry scope checked: the `SimpleRetryPolicy(..., [BcpAdapterException::class])` at
  `BcpExportAdapter.php:315` wraps only `doExport()`. `getColumns()` is called after `export()`
  returns, so no retry behaviour is affected by narrowing that class here.
- CDC fallback checked: `MSSQL.php` branches on the exception *message* ("The end LSN is less than
  the start LSN"), not the class, and the message is preserved — that fallback is unaffected.
- No existing test was modified or deleted.

## Scope of the reclassification (please read — it is wider than "login timeout")

Worth being explicit, because it is not obvious from the diff. `BaseDbConnection::callWithRetry()`
converts **every** `PDOException` from the `query()` call into a `UserRetriedException`, not only
transient ones. So this guard reclassifies **all DB-side failures of the metadata query** — bad
T-SQL in the generated `EXEC`, permission denied, invalid object name, deadlock — from exit 2 to
exit 1, not just the login timeout from the alert.

That is deliberate, for two reasons:

1. `BcpExportAdapter::export()` already converts **every** `BcpAdapterException` into a
   `UserException` (`BcpExportAdapter.php:92`). The repo's established position is therefore that
   BCP-adapter failures are user errors. The lazily-invoked metadata path was the single
   inconsistency, purely because it runs after `export()` has returned.
2. The metadata query wraps the **user's own query** (`sp_describe_first_result_set N'<user query>'`),
   so its DB-side failures are overwhelmingly user-side.

The trade-off, stated plainly: if the component's own single-quote escaping (`BcpQueryMetadata.php:33`)
ever produced invalid SQL, that would now be reported as a user error and would no longer raise an
internal-error alert. Narrowing the guard to `UserRetriedException` would not change this — every
`PDOException` from `query()` already arrives as one. Narrowing it to a `HYT00` / "Login timeout
expired" string match would, but at the cost of brittle message matching and of leaving
identically-shaped failures still paging the team. Happy to narrow if a maintainer prefers that.

Not affected either way: a raw `PDOException` from `fetchAll()` (which runs outside
`callWithRetry()`), a `RuntimeException`, or anything else not already user-classified still becomes
a `BcpAdapterException` and still exits 2.

## Evidence
Datadog monitor: https://app.datadoghq.eu/monitors/97152903

## Tests
New hermetic unit test `tests/phpunit/BcpQueryMetadataErrorClassificationTest.php` (5 tests,
21 assertions) — no DB required, the connection is mocked:

- `testRetriedTransientDbErrorStaysUserException` — a `UserRetriedException` (login timeout) stays
  a `UserExceptionInterface` and is **not** an `ApplicationExceptionInterface`. **Fails without this fix.**
- `testUserExceptionIsNotDowngraded` — same for the incomplete-metadata `UserException`. **Fails without this fix.**
- `testUnexpectedErrorStillBecomesApplicationException` / `testRawPdoExceptionStillBecomesApplicationException`
  / `testTempTableErrorKeepsDedicatedMessage` — the three unchanged-behaviour guards; they pass both
  with and without the fix.

`phpcs` clean. `phpstan --level=max` clean (`[OK] No errors`).

Local run of the rest of the unit suite is not possible on this machine: 39 of the 92 pre-existing
unit tests construct a real `MSSQLPdoConnection` and fail with `PDOException: could not find driver`
(no `pdo_sqlsrv`, no MSSQL service; the component image cannot be built on arm64 because
`mssql-tools` is amd64-only). That count is **identical on pristine `master` and on this branch**
— 39 errors before, 39 after — so this change introduces no new failures. The 53 unit tests that do
run locally pass, plus the 5 new ones. CI runs the full suite against MSSQL 2019 and 2022.


## CI note
`tests-in-kbc` failed on the first run with `error while waiting for the job ... context deadline
exceeded` — the action's 5-minute wait elapsed on one of the two test configs; the other config
finished successfully and no component exception was logged. This change only alters the class of an
exception on an already-failing path, so it cannot affect how long a job takes. Re-run to confirm.
`build`, `tests (2019)`, `tests (2022)` and `pr-reviewer-bot` all pass.
